### PR TITLE
Avoid mixing variables and indices. Handle unbounded cases.

### DIFF
--- a/lib/github.com/diku-dk/optimise/simplex-test.fut
+++ b/lib/github.com/diku-dk/optimise/simplex-test.fut
@@ -35,9 +35,24 @@ module S = mk_simplex f64
 --         [31.0,11.0] }
 -- output { 14.648352 }
 
+-- test 5
+-- ==
+-- input { empty([0][0]f64) empty([0]f64) empty([0]f64) }
+-- output { 0.0 }
+
+-- test 6
+-- ==
+-- input { [[1.0]] [5.0] [2.0] }
+-- output { 10.0 }
+
+-- test 7
+-- ==
+-- input { [[-0.5, 0.0, 0.0], [-0.5, -1.0, -1.0], [0.0, -1.0, 0.0]] [0.0, 0.0, 0.0] [0.0, 1.5, -1.0] }
+-- output { f64.inf }
+
 local open S
 
 let main [m] [n] (A:[m][n]t) (b:[m]t) (c:[n]t) =
-  let x = match simplex A b c case #Ok p -> p.0 case #Unbounded -> -1
-  let y = match simplex_orig A b c case #Ok p -> p.0 case #Unbounded -> -1
+  let x = match simplex A b c case #Ok p -> p.0 case #Unbounded -> f64.inf
+  let y = match simplex_orig A b c case #Ok p -> p.0 case #Unbounded -> f64.inf
   in (x+y) / 2.0

--- a/lib/github.com/diku-dk/optimise/simplex.fut
+++ b/lib/github.com/diku-dk/optimise/simplex.fut
@@ -47,9 +47,13 @@ module L = mk_linalg T
 
 type t = T.t
 
+type var = { name: i64 }
+
 ---------------------
 -- Some utilities
 ---------------------
+
+let novar: var = { name = -1 }
 
 -- [eye n] returns the identity matrix of size n x n.
 
@@ -67,6 +71,9 @@ let vecmatmul [n][m] (v:[m]t) (M:[m][n]t) : *[n]t =
 let matvecmul [n][m] (M:[n][m]t) (v:[m]t) : *[n]t =
   L.matvecmul_row M v
 
+let indexof [n] (xs: [n]var) (x: var): i64 =
+    xs |> map2 (\i x' -> if x == x' then i else n) (iota n) |> reduce i64.min n
+
 -- [init A b c] returns (xB,cB,B,bs,nbs), where xB is the initial
 -- vector of basic variable values, cB is the initial vector of basic
 -- variable function coefficients, B is the initial basis matrix, bs
@@ -75,23 +82,23 @@ let matvecmul [n][m] (M:[n][m]t) (v:[m]t) : *[n]t =
 -- enumerated from 0, starting with the original variables, then the
 -- slack variables.
 
-let init [m] (n:i64) (b:[m]t) : (*[m]t,*[m]t,*[m][m]t,*[m]i64,*[n]i64) =
-  (copy b,replicate m zero,eye m,map (+n) (iota m),iota n)
+let init [m] (n:i64) (b:[m]t) : (*[m]t,*[m]t,*[m][m]t,*[m]var,*[n]var) =
+  (copy b,replicate m zero,eye m,map (\name -> { name = name + n }) (iota m),map (\name -> { name }) (iota n))
 
-let entering [n][m] (A:[m][n]t) (Binv:[m][m]t) (cB:[m]t) (c:[n]t) (nbs:[n]i64) : i64 =
+let entering [n][m] (A:[m][n]t) (Binv:[m][m]t) (cB:[m]t) (c:[n]t) (nbs:[n]var) : var =
   let cB_Binv : *[m]t = vecmatmul cB Binv
   let orig : [n]t = map2 (T.-) (vecmatmul cB_Binv A) c
   let slack : [m]t = cB_Binv
-  let res = map (\i -> if i < n
-		       then (i,orig[i])
-		       else (i,slack[i-n])
+  let res: [n](var, t) = map (\v -> if v.name < n
+		       then (v,orig[v.name])
+		       else (v,slack[v.name - n])
 		) nbs
   in reduce (\x y -> if T.(x.1 < y.1) then x else y)
-	    (-1,zero) res
+	    (novar,zero) res
      |> (.0)
 
 let leaving [n][m] (A:[m][n]t) (xB:[m]t) (e:i64) : i64 =
-  map3 (\i a b -> T.((i,if i64 0 < a[e] then b/a[e] else inf)))
+  map3 (\i a b -> T.(if i64 0 < a[e] then (i, b/a[e]) else (-1, inf)))
        (iota m) A xB
   |> reduce (\x y -> if T.(x.1 < y.1) then x else y)
 	    (-1,inf)
@@ -113,24 +120,25 @@ type status = #FlagOk | #FlagUnbounded
 
 let simplexO [n][m] (A:[m][n]t) (b:[m]t) (c:[n]t) =
   let bound = n+m
-  let (xB:[m]t,cB:[m]t,B:[m][m]t,bs:[m]i64,nbs:[n]i64) = init n b
+  let (xB:[m]t,cB:[m]t,B:[m][m]t,bs:[m]var,nbs:[n]var) = init n b
   let I = eye m
   let k = entering A B cB c nbs
   in loop (B,xB,cB,k,bs,nbs,count,status:status) = (B,xB,cB,k,bs,nbs,0,#FlagOk)
-     while status == #FlagOk && k != -1 && continue count bound
-     do let r = leaving A xB k
-	in if r == -1
+     while status == #FlagOk && k != novar && continue count bound
+     do let ki = indexof nbs k
+        let ri = leaving A xB ki
+        let r = if ri == -1 then novar else bs[ri]
+	in if r == novar
 	   then (B,xB,cB,k,bs,nbs,count+1,#FlagUnbounded)
 	   else let B' =
-  		  let col = if k < n then A[:,k] else I[:,k-n]
-		  in B with [:,r] = col
+		  let col = if k.name < n then A[:,k.name] else I[:,k.name-n]
+		  in B with [:,ri] = col
   		let Binv' = L.inv B'
-  		let tmp_idx = bs[r]
-  		let bs' = bs with [r] = nbs[k]
-  		let nbs' = nbs with [k] = tmp_idx
+        let bs' = bs with [ri] = k
+        let nbs' = nbs with [ki] = r
   		let xB' = matvecmul Binv' b
-  		let cB' = cB with [r] = c[k]
-    	        let k' = entering A Binv' cB' c nbs'
+		let cB' = cB with [ri] = c[ki]
+        let k' = entering A Binv' cB' c nbs'
 		in (B',xB',cB',k',bs',nbs',count+1,#FlagOk)
 
 -- [simplexR A b c] returns intermediate data necessary for computing
@@ -145,29 +153,30 @@ let simplexO [n][m] (A:[m][n]t) (b:[m]t) (c:[n]t) =
 
 let simplexR [n][m] (A:[m][n]t) (b:[m]t) (c:[n]t) =
   let bound = n+m
-  let (xB:[m]t,cB:[m]t,Binv:[m][m]t,bs:[m]i64,nbs:[n]i64) = init n b
+  let (xB:[m]t,cB:[m]t,Binv:[m][m]t,bs:[m]var,nbs:[n]var) = init n b
   let k = entering A Binv cB c nbs
   in loop (Binv:[m][m]t,xB,cB,k,bs,nbs,count,status:status) = (Binv,xB,cB,k,bs,nbs,0,#FlagOk)
-     while status == #FlagOk && k != -1 && continue count bound
-     do let r = leaving A xB k
-	in if r == -1
+     while status == #FlagOk && k != novar && continue count bound
+     do let ki = indexof nbs k
+        let ri = leaving A xB ki
+        let r = if ri == -1 then novar else bs[ri]
+	in if r == novar
 	   then (Binv,xB,cB,k,bs,nbs,count+1,#FlagUnbounded)
-	   else let a_k' = if k < n
-			   then matvecmul Binv A[:,k]
-			   else Binv[:,k-n]
-  		let a_rk' = a_k'[r]
-  		let Binv_r = Binv[r]
-  		let Binv' = tabulate_2d m m
-					T.(\i j -> if i == r
+	   else let a_k' = if k.name < n
+			   then matvecmul Binv A[:,k.name]
+			   else Binv[:,k.name-n]
+		let a_rk' = a_k'[ri]
+		let Binv_r = Binv[ri]
+		let Binv' = tabulate_2d m m
+					T.(\i j -> if i == ri
 						   then Binv_r[j] / a_rk'
 						   else Binv[i,j] -
 							a_k'[i] * Binv_r[j] / a_rk'
 					  )
-  		let tmp_idx = bs[r]
-  		let bs' = bs with [r] = nbs[k]
-  		let nbs' = nbs with [k] = tmp_idx
+        let bs' = bs with [ri] = k
+        let nbs' = nbs with [ki] = r
   		let xB' = matvecmul Binv' b
-  		let cB' = cB with [r] = c[k]
+		let cB' = cB with [ri] = c[ki]
 		let k' = entering A Binv' cB' c nbs'
 		in (Binv',xB',cB',k',bs',nbs',count+1,#FlagOk)
 
@@ -175,12 +184,12 @@ type result [n] = #Ok (t,[n]t) | #Unbounded
 
 let runner [m][n]
 	   (looper: [m][n]t -> [m]t -> [n]t ->
-	      ([m][m]t,[m]t,[m]t,i64,[m]i64,[n]i64,i64,status))
+	      ([m][m]t,[m]t,[m]t,var,[m]var,[n]var,i64,status))
            (A:[m][n]t) (b:[m]t) (c:[n]t) : result[n] =
   let (_B,xB,cB,_,bs,_nbs,_count,status) = looper A b c
   in if status == #FlagUnbounded then #Unbounded
      else let h = n+m
-	  let sol = scatter (replicate h zero) bs xB
+	  let sol = scatter (replicate h zero) (map (.name) bs) xB
 	  let value = L.dotprod cB xB
 	  in #Ok (value,sol[:n])
 


### PR DESCRIPTION
Variable names (bounded by m+n) were used directly as indices in vectors/matrices of dimension m. They are now translated back first by computing the inverse mapping of that stored in bs/nbs. To make the distinction clearer variables are now wrapped in a struct.

The procedure for choosing a leaving variable is modified slightly to guarantee that -1 is returned when all choices are inf. This avoids infinite cycling when the solution is unbounded.