### PR TITLE
Stop when objective value cannot be improved.

### DIFF
--- a/lib/github.com/diku-dk/optimise/simplex-test.fut
+++ b/lib/github.com/diku-dk/optimise/simplex-test.fut
@@ -50,6 +50,11 @@ module S = mk_simplex f64
 -- input { [[-0.5, 0.0, 0.0], [-0.5, -1.0, -1.0], [0.0, -1.0, 0.0]] [0.0, 0.0, 0.0] [0.0, 1.5, -1.0] }
 -- output { f64.inf }
 
+-- test 8 (no improvement possible; will cycle if this is not detected)
+-- ==
+-- input { [[1.0]] [1.0] [0.0] }
+-- output { 0.0 }
+
 local open S
 
 let main [m] [n] (A:[m][n]t) (b:[m]t) (c:[n]t) =

--- a/lib/github.com/diku-dk/optimise/simplex.fut
+++ b/lib/github.com/diku-dk/optimise/simplex.fut
@@ -89,9 +89,9 @@ let entering [n][m] (A:[m][n]t) (Binv:[m][m]t) (cB:[m]t) (c:[n]t) (nbs:[n]var) :
   let cB_Binv : *[m]t = vecmatmul cB Binv
   let orig : [n]t = map2 (T.-) (vecmatmul cB_Binv A) c
   let slack : [m]t = cB_Binv
-  let res: [n](var, t) = map (\v -> if v.name < n
-		       then (v,orig[v.name])
-		       else (v,slack[v.name - n])
+  let res: [n](var, t) = map (\v ->
+               let c = if v.name < n then orig[v.name] else slack[v.name - n]
+               in if T.(c < zero) then (v, c) else (novar, zero)
 		) nbs
   in reduce (\x y -> if T.(x.1 < y.1) then x else y)
 	    (novar,zero) res


### PR DESCRIPTION
The condition for stopping when there is no suitable entering variable does not seem to ever have been detected. As a result, the algorithm would cycle in certain cases.